### PR TITLE
Bugfix - Update API.lua - Itemsearch was buggy when searching in cach…

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -36,11 +36,7 @@ local L = {
 --[[ Main API ]]--
 
 function Lib:Matches(item, search)
-	if type(item) == 'table' then
-    	return Parser({location = item, link = C_Item.GetItemLink(item)}, search, self.Filters)
-	else
-		return Parser({link = item}, search, self.Filters)
-	end
+	return Parser({link = item["hyperlink"]}, search, self.Filters)
 end
 
 function Lib:IsUnusable(id)


### PR DESCRIPTION
…es bankbags

I changed the search slithly, so it rather searches in a passed item than in Bagslot. Searching in Bank slot, when not at the bank, leads to an error, which has broken the search.

This PullRequest must be resolved together with https://github.com/Jaliborc/BagBrother/pull/32

